### PR TITLE
static is no op for fields, they are already globals

### DIFF
--- a/src/examples/clear.d
+++ b/src/examples/clear.d
@@ -11,9 +11,8 @@ import sapp = sokol.app;
 import log = sokol.log;
 
 extern (C):
-@safe:
 
-static sg.PassAction pass_action;
+__gshared sg.PassAction pass_action;
 
 void init()
 {


### PR DESCRIPTION
D globals are threadlocal, so it's better to tag them as __gshared to match C globals