### PR TITLE
[Draft] Proposal for fixing build.zig to work with unmodified cimgui.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -848,9 +848,12 @@ const libImGuiOptions = struct {
 };
 fn buildImgui(b: *Build, options: libImGuiOptions) !*CompileStep {
     const imgui_cpp = b.dependency("imgui", .{});
-    const imgui_cpp_dir = imgui_cpp.path("");
     const cimgui = b.dependency("cimgui", .{});
-    const cimgui_dir = cimgui.path("");
+
+    // create file tree for cimgui and imgui
+    const wf = b.addNamedWriteFiles("cimgui");
+    const cimgui_dir = wf.addCopyDirectory(cimgui.path(""), "", .{});
+    const imgui_cpp_dir = wf.addCopyDirectory(imgui_cpp.path(""), "imgui", .{});
 
     const libimgui = b.addStaticLibrary(.{
         .name = "cimgui",

--- a/build.zig
+++ b/build.zig
@@ -860,6 +860,10 @@ fn buildImgui(b: *Build, options: libImGuiOptions) !*CompileStep {
         .target = options.target,
         .optimize = options.optimize,
     });
+
+    // libimgui compilation depends on file tree
+    libimgui.step.dependOn(&wf.step);
+
     if (libimgui.linkage == .static)
         libimgui.pie = true
     else if (libimgui.linkage == .static)


### PR DESCRIPTION
Inspired by

https://github.com/floooh/sokol-zig-imgui-sample/blob/2597832beb515cf282189422d6fa4e84c8daa0b9/deps/cimgui/build.zig#L11-L15

...~~this makes `dub build :imgui` build without errors on my Mac~~. The resulting executable still doesn't run because it wants to load sokol as DLL, but I think/guess/hope that's unrelated:

```
build ➤ ./sokol-d_imgui
dyld[99581]: Library not loaded: @rpath/libsokol.dylib
  Referenced from: <57ED11C0-C30D-3C8C-A22E-53D217D831D7> /Users/floh/projects/sokol-d/build/sokol-d_imgui
  Reason: no LC_RPATH's found
[1]    99581 abort      ./sokol-d_imgui
```

closes: #26 