### PR TITLE
github ci: pin zig version to 0.13.0 (for now)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: korandoru/setup-zig@v1
         with:
-          zig-version: master
+          zig-version: 0.13.0
       - uses: dlang-community/setup-dlang@v2
         with:
           compiler: ldc-master


### PR DESCRIPTION
Just a quick fix to make the CI work again.

I already fixed the build.zig files in sokol-zig and dcimgui to work both with the latest 0.14.x changes (e.g. for dcimgui just pull the latest version instead of 1.91.6, and check sokol-zig's build.zig updates.

(let me know if you want me to integrate those changes into sokol-d/build.zig or if you want to do that yourself) :)