### PR TITLE
Fix latest zig 0.14.0-dev build system breakage

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -31,17 +31,39 @@ pub const LibSokolOptions = struct {
     cimgui_header_path: ?[]const u8 = null,
 };
 
+pub const TargetPlatform = enum {
+    android,
+    linux,
+    darwin, // macOS and iOS
+    macos,
+    ios,
+    windows,
+    web,
+};
+
+fn isPlatform(target: std.Target, platform: TargetPlatform) bool {
+    return switch (platform) {
+        .android => target.abi.isAndroid(),
+        .linux => target.os.tag == .linux,
+        .darwin => target.os.tag.isDarwin(),
+        .macos => target.os.tag == .macos,
+        .ios => target.os.tag == .ios,
+        .windows => target.os.tag == .windows,
+        .web => target.cpu.arch.isWasm(),
+    };
+}
+
 // helper function to resolve .auto backend based on target platform
 fn resolveSokolBackend(backend: SokolBackend, target: std.Target) SokolBackend {
     if (backend != .auto) {
         return backend;
-    } else if (target.os.tag.isDarwin()) {
+    } else if (isPlatform(target, .darwin)) {
         return .metal;
-    } else if (target.os.tag == .windows) {
+    } else if (isPlatform(target, .windows)) {
         return .d3d11;
-    } else if (target.cpu.arch.isWasm()) {
+    } else if (isPlatform(target, .web)) {
         return .gles3;
-    } else if (target.abi.isAndroid()) {
+    } else if (isPlatform(target, .android)) {
         return .gles3;
     } else {
         return .gl;
@@ -74,7 +96,7 @@ pub fn buildLibSokol(b: *Build, options: LibSokolOptions) !*CompileStep {
         .Debug, .ReleaseSafe => lib.bundle_compiler_rt = true,
         else => lib.root_module.strip = true,
     }
-    if (options.target.result.cpu.arch.isWasm()) {
+    if (isPlatform(options.target.result, .web)) {
         lib.root_module.root_source_file = b.path("src/handmade/math.zig");
         if (options.optimize != .Debug)
             lib.want_lto = true;
@@ -111,7 +133,7 @@ pub fn buildLibSokol(b: *Build, options: LibSokolOptions) !*CompileStep {
     }
 
     // platform specific compile and link options
-    if (lib.rootModuleTarget().os.tag.isDarwin()) {
+    if (isPlatform(lib.rootModuleTarget(), .darwin)) {
         try cflags.append("-ObjC");
         lib.linkFramework("Foundation");
         lib.linkFramework("AudioToolbox");
@@ -133,7 +155,7 @@ pub fn buildLibSokol(b: *Build, options: LibSokolOptions) !*CompileStep {
                 lib.linkFramework("OpenGL");
             }
         }
-    } else if (lib.rootModuleTarget().abi.isAndroid()) {
+    } else if (isPlatform(lib.rootModuleTarget(), .android)) {
         if (.gles3 != backend) {
             @panic("For android targets, you must have backend set to GLES3");
         }
@@ -329,11 +351,11 @@ pub fn build(b: *Build) !void {
                     "-preview=all",
                 },
                 // fixme: https://github.com/kassane/sokol-d/issues/1 - betterC works on darwin
-                .zig_cc = if (target.result.os.tag.isDarwin() and !opt_betterC) false else opt_zigcc,
+                .zig_cc = if (isPlatform(target.result, .darwin) and !opt_betterC) false else opt_zigcc,
                 .target = target,
                 .optimize = optimize,
                 // send ldc2-obj (wasm artifact) to emcc
-                .kind = if (target.result.cpu.arch.isWasm()) .obj else .exe,
+                .kind = if (isPlatform(target.result, .web)) .obj else .exe,
                 .emsdk = emsdk,
                 .backend = sokol_backend,
                 .with_sokol_imgui = opt_with_sokol_imgui,
@@ -377,14 +399,15 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
     if (options.kind == .lib) {
         if (options.linkage == .dynamic) {
             ldc_exec.addArg("-shared");
-            if (options.target.result.os.tag == .windows) {
+            if (isPlatform(options.target.result, .windows)) {
                 ldc_exec.addArg("-fvisibility=public");
                 ldc_exec.addArg("--dllimport=all");
             }
         } else {
             ldc_exec.addArg("-lib");
-            if (options.target.result.os.tag == .windows)
+            if (isPlatform(options.target.result, .windows)) {
                 ldc_exec.addArg("--dllimport=defaultLibsOnly");
+            }
             ldc_exec.addArg("-fvisibility=hidden");
         }
     }
@@ -463,7 +486,7 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
     const extFile = switch (options.kind) {
         .exe, .@"test" => options.target.result.exeFileExt(),
         .lib => if (options.linkage == .static) options.target.result.staticLibSuffix() else options.target.result.dynamicLibSuffix(),
-        .obj => if (options.target.result.os.tag == .windows) ".obj" else ".o",
+        .obj => if (isPlatform(options.target.result, .windows)) ".obj" else ".o",
     };
     // object file output (zig-cache/o/{hash_id}/*.o)
     const objpath = ldc_exec.addPrefixedOutputFileArg("-of=", try std.mem.concat(b.allocator, u8, &.{ options.name, extFile }));
@@ -508,16 +531,16 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
 
     // linker flags
     // GNU LD
-    if (options.target.result.os.tag == .linux and !options.zig_cc) {
+    if (isPlatform(options.target.result, .linux) and !options.zig_cc) {
         ldc_exec.addArg("-L--no-as-needed");
     }
     // LLD (not working in zld)
-    if (options.target.result.os.tag.isDarwin() and !options.zig_cc) {
+    if (isPlatform(options.target.result, .darwin) and !options.zig_cc) {
         // https://github.com/ldc-developers/ldc/issues/4501
         ldc_exec.addArg("-L-w"); // hide linker warnings
     }
 
-    if (options.target.result.cpu.arch.isWasm()) {
+    if (isPlatform(options.target.result, .web)) {
         ldc_exec.addArg("-L-allow-undefined");
 
         // Create a temporary D file for wasm assert function
@@ -641,7 +664,7 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
             ldc_exec.addArg("-L=-dead_strip");
         }
         // Darwin frameworks
-        if (options.target.result.os.tag.isDarwin()) {
+        if (isPlatform(options.target.result, .darwin)) {
             var it = lib_sokol.root_module.frameworks.iterator();
             while (it.next()) |framework| {
                 ldc_exec.addArg(b.fmt("-L-framework", .{}));
@@ -667,11 +690,11 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
     }
 
     // ldc2 doesn't support zig native (a.k.a: native-native or native)
-    const mtriple = if (options.target.result.os.tag.isDarwin())
+    const mtriple = if (isPlatform(options.target.result, .darwin))
         b.fmt("{s}-apple-{s}", .{ if (options.target.result.cpu.arch.isAARCH64()) "arm64" else @tagName(options.target.result.cpu.arch), @tagName(options.target.result.os.tag) })
-    else if (options.target.result.cpu.arch.isWasm() and options.target.result.os.tag == .freestanding)
+    else if (isPlatform(options.target.result, .web) and options.target.result.os.tag == .freestanding)
         b.fmt("{s}-unknown-unknown-wasm", .{@tagName(options.target.result.cpu.arch)})
-    else if (options.target.result.cpu.arch.isWasm())
+    else if (isPlatform(options.target.result, .web))
         b.fmt("{s}-unknown-{s}", .{ @tagName(options.target.result.cpu.arch), @tagName(options.target.result.os.tag) })
     else
         b.fmt("{s}-{s}-{s}", .{ @tagName(options.target.result.cpu.arch), @tagName(options.target.result.os.tag), @tagName(options.target.result.abi) });
@@ -715,7 +738,7 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
     else
         b.step("test", "Run all tests");
 
-    if (options.target.result.cpu.arch.isWasm()) {
+    if (isPlatform(options.target.result, .web)) {
         ldc_exec.step.dependOn(&options.artifact.?.step);
         // get D object file and put it in the wasm artifact
         const artifact = addArtifact(b, options);
@@ -1006,7 +1029,7 @@ fn buildShaders(b: *Build, target: Build.ResolvedTarget) void {
             return;
         }
         const shdc_path = b.findProgram(&.{"sokol-shdc"}, &.{}) catch b.pathJoin(&.{ sokol_tools_bin_dir, optional_shdc.? });
-        const glsl = if (target.result.os.tag.isDarwin()) "glsl410" else "glsl430";
+        const glsl = if (isPlatform(target.result, .darwin)) "glsl410" else "glsl430";
         const slang = glsl ++ ":metal_macos:hlsl5:glsl300es:wgsl";
         if (builtin.os.tag == .linux or builtin.os.tag == .macos) {
             const file = std.fs.openFileAbsolute(shdc_path, .{}) catch |err| {
@@ -1038,8 +1061,9 @@ fn buildShaders(b: *Build, target: Build.ResolvedTarget) void {
 
 // Enable fetch and install the Emscripten SDK
 fn enableWasm(b: *Build, target: Build.ResolvedTarget) ?*Build.Dependency {
-    if (target.result.cpu.arch.isWasm())
+    if (isPlatform(target.result, .web)) {
         return b.lazyDependency("emsdk", .{}) orelse null;
+    }
     return null;
 }
 


### PR DESCRIPTION
The Zig build system API had some breaking changes a couple of days ago, unfortunately the changes are not 0.13.0 compatible, so I made a PR.

Do we want to break 0.13.0 compatibility at this point or not? If not we should wrap the changes into a helper function which differentiates between 0.13.0 and 0.14.0 (I was thinking that this might be a good idea anyway because the checks are in so many places).