### PR TITLE
`build.zig` cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,4 +56,4 @@ jobs:
       - name: (Zig) Build Native
         run: zig build -Dimgui --summary all
       - name: (Zig + emsdk) Build Wasm
-        run: zig build -Dimgui -DzigCC --summary all -Dtarget=wasm32-emscripten-none -Doptimize=ReleaseSmall
+        run: zig build -Dimgui -DzigCC --summary all -Dtarget=wasm32-emscripten-none -Dcpu=generic

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,6 @@ jobs:
         if: runner.os != 'Windows'
         run: zig build test -DzigCC
       - name: (Zig) Build Native
-        run: zig build -Dimgui -DzigCC --summary all
+        run: zig build -Dimgui --summary all
       - name: (Zig + emsdk) Build Wasm
         run: zig build -Dimgui -DzigCC --summary all -Dtarget=wasm32-emscripten-none -Dcpu=generic

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         # with:
         #   version: master
       - uses: dlang-community/setup-dlang@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,6 @@ jobs:
         if: runner.os != 'Windows'
         run: zig build test -DzigCC
       - name: (Zig) Build Native
-        run: zig build -Dimgui --summary all
+        run: zig build -Dimgui -DzigCC --summary all
       - name: (Zig + emsdk) Build Wasm
         run: zig build -Dimgui -DzigCC --summary all -Dtarget=wasm32-emscripten-none -Dcpu=generic

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: D
 
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
 
 jobs:
   build:

--- a/build.zig
+++ b/build.zig
@@ -440,8 +440,12 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
     if (options.betterC)
         ldc_exec.addArg("-betterC");
 
-    // verbose error messages
-    ldc_exec.addArg("-verrors=context");
+    // verbose messages
+    ldc_exec.addArgs(&.{
+        "-verrors=context",
+        "-vgc",
+        "-vtls",
+    });
 
     switch (options.optimize) {
         .Debug => {
@@ -450,10 +454,10 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
                 "-d-debug",
                 "--gc",
                 "-g",
-                "-gf",
-                "-gs",
-                "-vgc",
-                "-vtls",
+                "--write-experimental-debuginfo",
+                "--data-sections",
+                "--function-sections",
+                "--force-dwarf-frame-section",
                 "-boundscheck=on",
                 "--link-debuglib",
             });
@@ -1121,7 +1125,7 @@ pub fn emLinkStep(b: *Build, options: EmLinkOptions) !*Build.Step.InstallDir {
         emcc.setName("emcc"); // hide emcc path
         if (options.optimize == .Debug) {
             emcc.addArgs(&.{
-                "-Og",
+                "-gsource-map",
                 "-sSAFE_HEAP=1",
                 "-sSTACK_OVERFLOW_CHECK=1",
             });

--- a/build.zig
+++ b/build.zig
@@ -447,6 +447,22 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
         "-vtls",
     });
 
+    if (options.optimize != .Debug) {
+        ldc_exec.addArgs(&.{
+            "--data-sections",
+            "--function-sections",
+        });
+        if (options.optimize != .ReleaseSafe) {
+            ldc_exec.addArgs(&.{
+                "-boundscheck=off",
+                "--enable-asserts=false",
+            });
+        } else {
+            ldc_exec.addArgs(&.{
+                "-boundscheck=safeonly",
+            });
+        }
+    }
     switch (options.optimize) {
         .Debug => {
             ldc_exec.addArgs(&.{
@@ -455,33 +471,21 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
                 "--gc",
                 "-g",
                 "--write-experimental-debuginfo",
-                "--data-sections",
-                "--function-sections",
                 "--force-dwarf-frame-section",
                 "-boundscheck=on",
                 "--link-debuglib",
             });
         },
-        .ReleaseSafe => {
+        .ReleaseSafe, .ReleaseFast => {
             ldc_exec.addArgs(&.{
                 "-O",
-                "-boundscheck=safeonly",
-            });
-        },
-        .ReleaseFast => {
-            ldc_exec.addArgs(&.{
-                "-O",
-                "-boundscheck=off",
-                "--enable-asserts=false",
-                "--strip-debug",
             });
         },
         .ReleaseSmall => {
             ldc_exec.addArgs(&.{
-                "-Oz",
-                "-boundscheck=off",
-                "--enable-asserts=false",
+                "-Os",
                 "--strip-debug",
+                "--strip-global-constants",
             });
         },
     }

--- a/build.zig
+++ b/build.zig
@@ -1317,7 +1317,7 @@ fn buildImgui(b: *Build, options: libImGuiOptions) !*CompileStep {
             },
             .flags = cflags.slice(),
         });
-        libimgui.root_module.sanitize_c = false;
+
         if (libimgui.rootModuleTarget().os.tag == .windows)
             libimgui.linkSystemLibrary("imm32");
 

--- a/build.zig
+++ b/build.zig
@@ -725,31 +725,31 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
 
     ldc_exec.addArg(b.fmt("-mtriple={s}", .{mtriple}));
 
-    const cpu_model = options.target.result.cpu.model.llvm_name orelse "generic";
-    ldc_exec.addArg(b.fmt("-mcpu={s}", .{cpu_model}));
+    if (options.target.query.isNative()) {
+        ldc_exec.addArg("-mcpu=native");
+    } else {
+        const cpu_model = options.target.result.cpu.model.llvm_name orelse "generic";
+        ldc_exec.addArg(b.fmt("-mcpu={s}", .{cpu_model}));
 
-    // zig workaround for ldc2 get cpu-features
-    var cpu_args = std.ArrayList(u8).init(b.allocator);
-    defer cpu_args.deinit();
-    const all_features_list = options.target.result.cpu.arch.allFeaturesList();
-    for (all_features_list, 0..) |feature, index_usize| {
-        const index = @as(std.Target.Cpu.Feature.Set.Index, @intCast(index_usize));
-        const is_enabled = options.target.result.cpu.features.isEnabled(index);
-        if (feature.llvm_name) |llvm_name| {
-            const plus_or_minus = "-+"[@intFromBool(is_enabled)];
-            if (is_enabled) {
-                if (std.mem.endsWith(u8, llvm_name, "contextidrel2")) {
-                    try cpu_args.writer().print("{c}CONTEXTIDREL2,", .{plus_or_minus});
-                } else {
+        // zig workaround for ldc2 get cpu-features
+        var cpu_args = std.ArrayList(u8).init(b.allocator);
+        defer cpu_args.deinit();
+        const all_features_list = options.target.result.cpu.arch.allFeaturesList();
+        for (all_features_list, 0..) |feature, index_usize| {
+            const index = @as(std.Target.Cpu.Feature.Set.Index, @intCast(index_usize));
+            const is_enabled = options.target.result.cpu.features.isEnabled(index);
+            if (feature.llvm_name) |llvm_name| {
+                const plus_or_minus = "-+"[@intFromBool(is_enabled)];
+                if (is_enabled) {
                     try cpu_args.writer().print("{c}{s},", .{ plus_or_minus, llvm_name });
                 }
             }
         }
-    }
-    if (cpu_args.items.len > 0) {
-        // Remove trailing comma
-        _ = cpu_args.pop();
-        ldc_exec.addArg(b.fmt("-mattr={s}", .{cpu_args.items}));
+        if (cpu_args.items.len > 0) {
+            // Remove trailing comma
+            _ = cpu_args.pop();
+            ldc_exec.addArg(b.fmt("-mattr={s}", .{cpu_args.items}));
+        }
     }
 
     var outputDir: []const u8 = undefined;

--- a/build.zig
+++ b/build.zig
@@ -999,6 +999,13 @@ const generated_zcc =
     \\             or std.mem.startsWith(u8, arg, "/DE") or std.mem.startsWith(u8, arg, "/IG"))
     \\         {
     \\             // NOT CHANGE!!
+    \\         } else if (std.mem.endsWith(u8, arg, "32.lib")
+    \\             or std.mem.startsWith(u8, arg, "oldnames") 
+    \\             or std.mem.startsWith(u8, arg, "legacy_stdio_definitions")
+    \\             or std.mem.startsWith(u8, arg, "uuid") 
+    \\             or std.mem.startsWith(u8, arg, "winspool"))
+    \\         {
+    \\             // NOT CHANGE!!
     \\         } else if (std.mem.endsWith(u8, arg, "gcc") or
     \\             std.mem.endsWith(u8, arg, "gcc_s"))
     \\         {

--- a/build.zig
+++ b/build.zig
@@ -999,11 +999,7 @@ const generated_zcc =
     \\             or std.mem.startsWith(u8, arg, "/DE") or std.mem.startsWith(u8, arg, "/IG"))
     \\         {
     \\             // NOT CHANGE!!
-    \\         } else if (std.mem.endsWith(u8, arg, "32.lib")
-    \\             or std.mem.startsWith(u8, arg, "oldnames") 
-    \\             or std.mem.startsWith(u8, arg, "legacy_stdio_definitions")
-    \\             or std.mem.startsWith(u8, arg, "uuid") 
-    \\             or std.mem.startsWith(u8, arg, "winspool"))
+    \\         } else if (std.mem.endsWith(u8, arg, ".lib"))
     \\         {
     \\             // NOT CHANGE!!
     \\         } else if (std.mem.endsWith(u8, arg, "gcc") or

--- a/build.zig
+++ b/build.zig
@@ -738,7 +738,11 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
         if (feature.llvm_name) |llvm_name| {
             const plus_or_minus = "-+"[@intFromBool(is_enabled)];
             if (is_enabled) {
-                try cpu_args.writer().print("{c}{s},", .{ plus_or_minus, llvm_name });
+                if (std.mem.endsWith(u8, llvm_name, "contextidrel2")) {
+                    try cpu_args.writer().print("{c}CONTEXTIDREL2,", .{plus_or_minus});
+                } else {
+                    try cpu_args.writer().print("{c}{s},", .{ plus_or_minus, llvm_name });
+                }
             }
         }
     }

--- a/build.zig
+++ b/build.zig
@@ -996,7 +996,7 @@ const generated_zcc =
     \\         } else if (std.mem.startsWith(u8, arg, "/NOLOGO") or
     \\             std.mem.startsWith(u8, arg, "/P") or std.mem.startsWith(u8, arg, "/F")
     \\             or std.mem.startsWith(u8, arg, "/Zc") or std.mem.startsWith(u8, arg, "/O") 
-    \\             or std.mem.startsWith(u8, arg, "/DEB") or std.mem.startsWith(u8, arg, "/IG"))
+    \\             or std.mem.startsWith(u8, arg, "/DE") or std.mem.startsWith(u8, arg, "/IG"))
     \\         {
     \\             // NOT CHANGE!!
     \\         } else if (std.mem.endsWith(u8, arg, "gcc") or

--- a/build.zig
+++ b/build.zig
@@ -993,7 +993,7 @@ const generated_zcc =
     \\             // NOT CHANGE!!
     \\         } else if (std.mem.endsWith(u8, arg, "as-needed")) {
     \\             // NOT CHANGE!!
-    \\         } else if (std.mem.startsWith(u8, arg, "/NOLOGO") or
+    \\         } else if (std.mem.startsWith(u8, arg, "/NOLOGO") or std.mem.startsWith(u8, arg, "/nologo")
     \\             std.mem.startsWith(u8, arg, "/P") or std.mem.startsWith(u8, arg, "/F")
     \\             or std.mem.startsWith(u8, arg, "/Zc") or std.mem.startsWith(u8, arg, "/O") 
     \\             or std.mem.startsWith(u8, arg, "/DE") or std.mem.startsWith(u8, arg, "/IG"))

--- a/build.zig
+++ b/build.zig
@@ -993,6 +993,11 @@ const generated_zcc =
     \\             // NOT CHANGE!!
     \\         } else if (std.mem.endsWith(u8, arg, "as-needed")) {
     \\             // NOT CHANGE!!
+    \\         } else if (std.mem.startsWith(u8, arg, "/NOLOGO") or
+    \\             std.mem.startsWith(u8, arg, "/P") or std.mem.startsWith(u8, arg, "/F")
+    \\             or std.mem.startsWith(u8, arg, "/Zc"))
+    \\         {
+    \\             // NOT CHANGE!!
     \\         } else if (std.mem.endsWith(u8, arg, "gcc") or
     \\             std.mem.endsWith(u8, arg, "gcc_s"))
     \\         {

--- a/build.zig
+++ b/build.zig
@@ -996,7 +996,7 @@ const generated_zcc =
     \\         } else if (std.mem.startsWith(u8, arg, "/NOLOGO") or
     \\             std.mem.startsWith(u8, arg, "/P") or std.mem.startsWith(u8, arg, "/F")
     \\             or std.mem.startsWith(u8, arg, "/Zc") or std.mem.startsWith(u8, arg, "/O") 
-    \\             or std.mem.startsWith(u8, arg, "/DE") or std.mem.startsWith(u8, arg, "/I"))
+    \\             or std.mem.startsWith(u8, arg, "/DEB") or std.mem.startsWith(u8, arg, "/IG"))
     \\         {
     \\             // NOT CHANGE!!
     \\         } else if (std.mem.endsWith(u8, arg, "gcc") or

--- a/build.zig
+++ b/build.zig
@@ -1002,6 +1002,7 @@ const generated_zcc =
     \\         } else if (std.mem.endsWith(u8, arg, "32.lib")
     \\             or std.mem.startsWith(u8, arg, "oldnames") 
     \\             or std.mem.startsWith(u8, arg, "legacy_stdio_definitions")
+    \\             or std.mem.startsWith(u8, arg, "d3d11") 
     \\             or std.mem.startsWith(u8, arg, "uuid") 
     \\             or std.mem.startsWith(u8, arg, "winspool"))
     \\         {

--- a/build.zig
+++ b/build.zig
@@ -999,7 +999,11 @@ const generated_zcc =
     \\             or std.mem.startsWith(u8, arg, "/DE") or std.mem.startsWith(u8, arg, "/IG"))
     \\         {
     \\             // NOT CHANGE!!
-    \\         } else if (std.mem.endsWith(u8, arg, ".lib"))
+    \\         } else if (std.mem.endsWith(u8, arg, "32.lib")
+    \\             or std.mem.startsWith(u8, arg, "oldnames") 
+    \\             or std.mem.startsWith(u8, arg, "legacy_stdio_definitions")
+    \\             or std.mem.startsWith(u8, arg, "uuid") 
+    \\             or std.mem.startsWith(u8, arg, "winspool"))
     \\         {
     \\             // NOT CHANGE!!
     \\         } else if (std.mem.endsWith(u8, arg, "gcc") or

--- a/build.zig
+++ b/build.zig
@@ -994,7 +994,7 @@ const generated_zcc =
     \\         } else if (std.mem.endsWith(u8, arg, "as-needed")) {
     \\             // NOT CHANGE!!
     \\         } else if (std.mem.startsWith(u8, arg, "/NOLOGO") or std.mem.startsWith(u8, arg, "/nologo")
-    \\             std.mem.startsWith(u8, arg, "/P") or std.mem.startsWith(u8, arg, "/F")
+    \\             or std.mem.startsWith(u8, arg, "/P") or std.mem.startsWith(u8, arg, "/F")
     \\             or std.mem.startsWith(u8, arg, "/Zc") or std.mem.startsWith(u8, arg, "/O") 
     \\             or std.mem.startsWith(u8, arg, "/DE") or std.mem.startsWith(u8, arg, "/IG"))
     \\         {

--- a/build.zig
+++ b/build.zig
@@ -85,10 +85,7 @@ pub fn buildLibSokol(b: *Build, options: LibSokolOptions) !*CompileStep {
         }),
         .linkage = if (options.dynamic_linking) .dynamic else .static,
     });
-
     lib.linkLibC();
-
-    lib.root_module.sanitize_c = options.use_ubsan;
     lib.root_module.sanitize_thread = options.use_tsan;
 
     switch (options.optimize) {
@@ -120,6 +117,9 @@ pub fn buildLibSokol(b: *Build, options: LibSokolOptions) !*CompileStep {
     try cflags.append("-DIMPL");
     if (options.optimize != .Debug) {
         try cflags.append("-DNDEBUG");
+    }
+    if (!options.use_ubsan) {
+        try cflags.append("-fno-sanitize=undefined");
     }
     const backend = resolveSokolBackend(options.backend, lib.rootModuleTarget());
     switch (backend) {
@@ -344,6 +344,7 @@ pub fn build(b: *Build) !void {
                 .name = example,
                 .artifact = lib_sokol,
                 .imgui = lib_imgui,
+                .use_ubsan = sanitize_c,
                 .sources = &[_][]const u8{
                     b.fmt("{s}/examples/{s}.d", .{ rootPath(), example }),
                 },
@@ -821,7 +822,7 @@ pub fn ldcBuildStep(b: *Build, options: DCompileStep) !*Build.Step.InstallDir {
             .use_webgl2 = backend != .wgpu,
             .use_emmalloc = true,
             .use_filesystem = false,
-            .use_ubsan = options.artifact.?.root_module.sanitize_c orelse false,
+            .use_ubsan = options.use_ubsan,
             .release_use_lto = options.artifact.?.want_lto orelse false,
             .shell_file_path = b.path("src/sokol/web/shell.html"),
             .extra_args = &.{"-sSTACK_SIZE=512KB"},
@@ -873,6 +874,7 @@ pub const DCompileStep = struct {
     artifact: ?*Build.Step.Compile = null,
     imgui: ?*Build.Step.Compile = null,
     with_sokol_imgui: bool = false,
+    use_ubsan: bool = false,
     emsdk: ?*Build.Dependency = null,
     backend: SokolBackend = .auto,
 };
@@ -1195,8 +1197,8 @@ pub fn emLinkStep(b: *Build, options: EmLinkOptions) !*Build.Step.InstallDir {
         if (options.use_offset_converter) {
             emcc.addArg("-sUSE_OFFSET_CONVERTER");
         }
-        if (options.use_ubsan) {
-            emcc.addArg("-fsanitize=undefined");
+        if (!options.use_ubsan) {
+            emcc.addArg("-fno-sanitize=undefined");
         }
         if (options.shell_file_path) |shell_file_path| {
             emcc.addPrefixedFileArg("--shell-file=", shell_file_path);
@@ -1309,13 +1311,14 @@ fn buildImgui(b: *Build, options: libImGuiOptions) !*CompileStep {
         .target = options.target,
         .optimize = options.optimize,
     });
-
-    libimgui.root_module.sanitize_c = options.use_ubsan;
     libimgui.root_module.sanitize_thread = options.use_tsan;
 
     var cflags = try std.BoundedArray([]const u8, 64).init(0);
     if (options.optimize != .Debug) {
         try cflags.append("-DNDEBUG");
+    }
+    if (!options.use_ubsan) {
+        try cflags.append("-fno-sanitize=undefined");
     }
     try cflags.appendSlice(&.{
         "-Wall",

--- a/build.zig
+++ b/build.zig
@@ -995,7 +995,8 @@ const generated_zcc =
     \\             // NOT CHANGE!!
     \\         } else if (std.mem.startsWith(u8, arg, "/NOLOGO") or
     \\             std.mem.startsWith(u8, arg, "/P") or std.mem.startsWith(u8, arg, "/F")
-    \\             or std.mem.startsWith(u8, arg, "/Zc"))
+    \\             or std.mem.startsWith(u8, arg, "/Zc") or std.mem.startsWith(u8, arg, "/O") 
+    \\             or std.mem.startsWith(u8, arg, "/DE") or std.mem.startsWith(u8, arg, "/I"))
     \\         {
     \\             // NOT CHANGE!!
     \\         } else if (std.mem.endsWith(u8, arg, "gcc") or

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,11 +1,10 @@
 .{
     .name = .sokol,
-    .version = "0.2.0",
+    .version = "0.2.1",
     .min_zig_version = "0.14.0",
     .fingerprint = 0xf9f6f48d67869e98,
     .paths = .{
         "src",
-        "tools",
         "build.zig",
         "build.zig.zon",
         "LICENSE",

--- a/dub.sdl
+++ b/dub.sdl
@@ -1,5 +1,5 @@
 name "sokol-d"
-version "0.2.0"
+version "0.2.1"
 description "D bindings for sokol"
 authors "Matheus Catarino França" "Andre Weissflog"
 copyright "Copyright 2023-2024 - Matheus Catarino França"
@@ -24,7 +24,7 @@ buildType "release-nobounds" {
 buildType "release-debug" {
 	buildOptions "releaseMode" "debugInfo" "inline" "optimize"
 }
-toolchainRequirements dmd=">=2.105.0" ldc=">=1.35.0" gdc=">=9.3.0"
+toolchainRequirements frontend=">=2.105.0"
 
 configuration "default" {
 	targetType "sourceLibrary"

--- a/examples/user_data.d
+++ b/examples/user_data.d
@@ -43,17 +43,17 @@ void frame_userdata(scope void* userdata) @trusted
         {
             state.map.clear();
         }
-    }
-    debug
-    {
-        import std.stdio : writeln;
+        debug
+        {
+            import std.stdio : writeln;
 
-        try
-        {
-            writeln(*state);
-        }
-        catch (Exception)
-        {
+            try
+            {
+                writeln(*state);
+            }
+            catch (Exception)
+            {
+            }
         }
     }
 


### PR DESCRIPTION
## Steps
- [x] Fix debug mode for wasm32[^1]
- [x] Fix `ubsan` disable/enable
- [x] LLVM cpu-features mismatch fixed (generic isn't empty) see: https://github.com/ldc-developers/ldc/issues/4919
- [x] fix user_data example for wasm32-target (ignore `writeln`/`Exception`)

closes: #66 

[^1]: ldc2 no emit dwarf info for wasm32, see: https://github.com/ldc-developers/ldc/issues/4801