### PR TITLE
build: per-target output dirs to prevent wasm/native clobbering

### DIFF
--- a/build.d
+++ b/build.d
@@ -397,12 +397,16 @@ string includeFlag(string path, string target) @safe pure nothrow
 
 void buildLibSokol(LibSokolOptions opts) @safe
 {
-    immutable buildDir = absolutePath("build");
-    mkdirRecurse(buildDir);
-
     immutable isWin = targetIsWindows(opts.target);
     immutable isMac = targetIsDarwin(opts.target);
     immutable isWasm = targetIsWasm(opts.target);
+
+    // Per-target output dirs so wasm and native archives don't overwrite
+    // each other. "build/" is kept as a mirror of the most recent target.
+    immutable buildSubdir = isWasm ? "build-wasm" : "build-native";
+    immutable buildDir = absolutePath(buildSubdir);
+    mkdirRecurse(buildDir);
+    mkdirRecurse(absolutePath("build"));
 
     string compiler = opts.toolchain ? opts.toolchain : defaultCompiler(opts.target);
 
@@ -602,6 +606,26 @@ void buildLibSokol(LibSokolOptions opts) @safe
             opts.vendor, lflags, opts.verbose);
         if (exists(objPath))
             remove(objPath);
+    }
+
+    // Mirror to legacy "build/" for back-compat with consumers that
+    // reference build/libsokol.a unqualified (e.g. dub's targetPath).
+    {
+        import std.file : copy, exists, remove;
+        immutable legacyDir = absolutePath("build");
+        foreach (libBase; ["libsokol.a", "libcimgui.a", "libnuklear.a",
+                           "libsokol.so", "libcimgui.so", "libnuklear.so",
+                           "sokol.lib", "cimgui.lib", "nuklear.lib",
+                           "sokol.dll", "cimgui.dll", "nuklear.dll",
+                           "libsokol.dylib", "libcimgui.dylib", "libnuklear.dylib"])
+        {
+            immutable src = buildPath(buildDir, libBase);
+            immutable dst = buildPath(legacyDir, libBase);
+            if (!exists(src)) continue;
+            if (exists(dst))
+                try { remove(dst); } catch (Exception) {}
+            try { copy(src, dst); } catch (Exception) {}
+        }
     }
 }
 


### PR DESCRIPTION
disclaimer, i use AI to fix and write this. 

buildLibSokol() previously wrote every target into a single "build/" directory, so a wasm build right after a native one (or vice versa) overwrote libsokol.a with objects of the wrong format. The next build then failed with "file format not recognized" when the linker was handed wasm objects on x86_64 (or the inverse).

Native targets now write to "build-native/" and wasm targets to "build-wasm/". The legacy "build/" path is preserved as a mirror of the most recently built target so consumers that reference "build/libsokol.a" unqualified (notably dub's default targetPath configured in dub.json) keep working unchanged. Consumers that need a specific target should reference "build-native/<lib>" or "build-wasm/<lib>" directly.